### PR TITLE
Fix type of titles property

### DIFF
--- a/src/typings/anime.ts
+++ b/src/typings/anime.ts
@@ -26,7 +26,10 @@ export interface IAnime {
         }
     }
     approved: boolean
-    titles: string[]
+    titles: {
+        type: string,
+        title: string,
+    }[],
     title: string
     title_english: string
     title_japanese: string


### PR DESCRIPTION
The [documentation](https://docs.api.jikan.moe/#tag/anime/operation/getAnimeFullById) says that this is an array of strings, but [this is incorrect](https://github.com/jikan-me/jikan/issues/473). 