### PR TITLE
Fixed character voice actors array

### DIFF
--- a/src/typings/anime.ts
+++ b/src/typings/anime.ts
@@ -151,7 +151,7 @@ export interface IAnimeCharacters {
                 name: string
             }
             language: string
-        }
+        }[]
     }[]
 }
 


### PR DESCRIPTION
In the [documentation](https://docs.api.jikan.moe/#tag/anime/operation/getAnimeCharacters) the value of voice_actors returns a list and not a single object